### PR TITLE
要約機能の UI 部分実装

### DIFF
--- a/assets/aoai_icon.svg
+++ b/assets/aoai_icon.svg
@@ -1,0 +1,9 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 2.7V15.3C0 16.791 1.209 18 2.7 18H15.3C16.791 18 18 16.791 18 15.3V2.7C18 1.209 16.791 0 15.3 0H2.7C1.209 0 0 1.209 0 2.7ZM10.8 0V3.6C10.8 7.576 14.024 10.8 18 10.8H14.4C10.424 10.8 7.201 14.022 7.2 17.998V14.4C7.2 10.424 3.976 7.2 0 7.2H3.6C7.576 7.2 10.8 3.976 10.8 0Z" fill="url(#paint0_radial_10_17)"/>
+<defs>
+<radialGradient id="paint0_radial_10_17" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(8.2179 8.54109) rotate(45) scale(11.2909 15.367)">
+<stop stop-color="#83B9F9"/>
+<stop offset="1" stop-color="#0078D4"/>
+</radialGradient>
+</defs>
+</svg>

--- a/contents/components/SummaryCard.tsx
+++ b/contents/components/SummaryCard.tsx
@@ -1,0 +1,19 @@
+import aoaiIcon from 'data-base64:~assets/aoai_icon.svg';
+
+export const SummaryCard = ({
+  title,
+  body
+}: {
+  title: string;
+  body: string;
+}) => {
+  return (
+    <div className="mldi_card_base">
+      <div className="card_title">
+        <img className="card_title_icon" src={aoaiIcon} alt="AOAI" />
+        <div className="card_title_text">{title}</div>
+      </div>
+      <div className="card_body">{body}</div>
+    </div>
+  );
+};

--- a/contents/content.tsx
+++ b/contents/content.tsx
@@ -1,19 +1,13 @@
-import type { PlasmoCSConfig, PlasmoGetInlineAnchor } from "plasmo";
-import type { SwResponse } from "@advanced-microsoft-learn-innovators/mldi-types";
+import type { PlasmoCSConfig, PlasmoGetInlineAnchor } from 'plasmo';
+import type { SwResponse } from '@advanced-microsoft-learn-innovators/mldi-types';
 
-/**
- * Plasmo configuration for the content script.
- */
 export const config: PlasmoCSConfig = {
-  matches: ["https://learn.microsoft.com/*"],
+  matches: ['https://learn.microsoft.com/*']
 };
 
-/**
- * Get the inline anchor for the Plasmo inline.
- */
 export const getInlineAnchor: PlasmoGetInlineAnchor = async () => ({
-  element: document.getElementsByTagName("h1")[0],
-  position: "afterend",
+  element: document.getElementsByTagName('h1')[0],
+  position: 'afterend'
 });
 
 /**
@@ -22,18 +16,18 @@ export const getInlineAnchor: PlasmoGetInlineAnchor = async () => ({
  */
 const getSenderTabId = (callback: (tabId: number) => void) => {
   chrome.runtime.sendMessage(
-    { requestType: "getSenderTabId" },
+    { requestType: 'getSenderTabId' },
     (response: SwResponse) => {
-      if (response.isSuccess && response.type === "tabId") {
+      if (response.isSuccess && response.type === 'tabId') {
         callback(response.tabId);
-      } else if (response.isSuccess && response.type !== "tabId") {
+      } else if (response.isSuccess && response.type !== 'tabId') {
         //error
-        console.error("Invalid response type");
+        console.error('Invalid response type');
       } else {
         // error
         console.error(response);
       }
-    },
+    }
   );
 };
 
@@ -46,26 +40,26 @@ const getSenderTabId = (callback: (tabId: number) => void) => {
 const getApiRes = (
   callback: (apiResponse: any) => void,
   currentUrl: string,
-  senderTabId: number,
+  senderTabId: number
 ) => {
   // send message to background SW to call Rest API
   chrome.runtime.sendMessage(
     {
-      requestType: "callRESTApiNestJS",
+      requestType: 'callRESTApiNestJS',
       currentUrl: currentUrl,
-      senderTabId: senderTabId,
+      senderTabId: senderTabId
     },
     (response: SwResponse) => {
-      if (response.isSuccess && response.type === "apiRes") {
+      if (response.isSuccess && response.type === 'apiRes') {
         callback(response.apiResponse);
-      } else if (response.isSuccess && response.type !== "apiRes") {
+      } else if (response.isSuccess && response.type !== 'apiRes') {
         // error
-        console.error("Invalid response type");
+        console.error('Invalid response type');
       } else {
         // error
         console.error(response);
       }
-    },
+    }
   );
 };
 
@@ -83,7 +77,7 @@ const PlasmoInline = () => {
           console.log(apiResponse);
         },
         currentUrl,
-        senderTabId,
+        senderTabId
       );
     });
   };
@@ -93,7 +87,7 @@ const PlasmoInline = () => {
       style={{
         borderRadius: 4,
         padding: 4,
-        background: "pink",
+        background: 'pink'
       }}
     >
       <button onClick={handleClick}>Toggle REST API via background SW</button>

--- a/contents/overall-summary.tsx
+++ b/contents/overall-summary.tsx
@@ -1,0 +1,47 @@
+import type {
+  PlasmoCSConfig,
+  PlasmoGetInlineAnchor,
+  PlasmoGetStyle
+} from 'plasmo';
+import { useEffect, useState } from 'react';
+import { SummaryCard } from './components/SummaryCard';
+import summaryCardStyle from 'data-text:./styles/SummaryCard.scss';
+
+/**
+ * Plasmo configuration for the content script.
+ */
+export const config: PlasmoCSConfig = {
+  matches: ['https://learn.microsoft.com/*']
+};
+
+/**
+ * Get the inline anchor for the Plasmo inline.
+ */
+export const getInlineAnchor: PlasmoGetInlineAnchor = async () => ({
+  element: document.getElementById('center-doc-outline'),
+  position: 'afterend'
+});
+
+/**
+ * Get the styles
+ * @returns HTMLStyleElement
+ */
+export const getStyle: PlasmoGetStyle = () => {
+  const style = document.createElement('style');
+  style.textContent += summaryCardStyle;
+  return style;
+};
+
+const overallSummary = () => {
+  const [abstract, setAbstract] = useState('');
+
+  useEffect(() => {
+    setAbstract(
+      'これが要約内容です。できれば 150 字以内で収めたいところ。ああああああああ Teams あああああああああああああああああああああ'
+    );
+  }, []);
+
+  return <SummaryCard title="要約" body={abstract} />;
+};
+
+export default overallSummary;

--- a/contents/section-summary.tsx
+++ b/contents/section-summary.tsx
@@ -1,0 +1,56 @@
+import type {
+  PlasmoCSConfig,
+  PlasmoGetInlineAnchorList,
+  PlasmoGetStyle
+} from 'plasmo';
+import { useEffect, useState } from 'react';
+import { SummaryCard } from './components/SummaryCard';
+import summaryCardStyle from 'data-text:./styles/SummaryCard.scss';
+
+/**
+ * Plasmo configuration for the content script.
+ */
+export const config: PlasmoCSConfig = {
+  matches: ['https://learn.microsoft.com/*']
+};
+
+/**
+ * Get the inline anchor for the Plasmo inline.
+ */
+export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
+  const anchors = document.querySelectorAll('h2.heading-anchor');
+  return Array.from(anchors).map((element) => ({
+    element,
+    insertPosition: 'afterend'
+  }));
+};
+
+/**
+ * Get the styles
+ * @returns HTMLStyleElement
+ */
+export const getStyle: PlasmoGetStyle = () => {
+  const style = document.createElement('style');
+  style.textContent += summaryCardStyle;
+  return style;
+};
+
+/**
+ *
+ * @param anchor
+ * @returns
+ */
+const sectionSummary = ({ anchor }) => {
+  const [abstract, setAbstract] = useState('');
+
+  useEffect(() => {
+    setAbstract(
+      anchor.element.id +
+        `: これが${anchor.element.innerText}の要約内容です。できれば 100 字以内で収めたいところ。ああああああああ Teams あああああああああああああああああああああ`
+    );
+  }, []);
+
+  return <SummaryCard title="段落要約" body={abstract} />;
+};
+
+export default sectionSummary;

--- a/contents/styles/SummaryCard.scss
+++ b/contents/styles/SummaryCard.scss
@@ -1,3 +1,6 @@
+$default-font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
+  sans-serif;
+
 .mldi_card_base {
   background-color: #f2f2f2;
   border-radius: 6px;
@@ -5,8 +8,7 @@
   margin-left: 0px;
   margin-right: 0px;
   padding: 16px;
-  font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
-    sans-serif;
+  font-family: $default-font-family;
 
   .card_title {
     font-weight: 600;
@@ -19,8 +21,7 @@
     }
 
     .card_title_text {
-      font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
-        sans-serif;
+      font-family: $default-font-family;
       font-size: 16px;
       color: #555555;
       margin-left: 8px;
@@ -29,8 +30,7 @@
   }
 
   .card_body {
-    font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
-      sans-serif;
+    font-family: $default-font-family;
     font-size: 16px;
     margin-top: 16px;
   }

--- a/contents/styles/SummaryCard.scss
+++ b/contents/styles/SummaryCard.scss
@@ -1,0 +1,37 @@
+.mldi_card_base {
+  background-color: #f2f2f2;
+  border-radius: 6px;
+  flex-basis: 100%;
+  margin-left: 0px;
+  margin-right: 0px;
+  padding: 16px;
+  font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
+    sans-serif;
+
+  .card_title {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+
+    .card_title_icon {
+      width: 16px;
+      height: 16px;
+    }
+
+    .card_title_text {
+      font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
+        sans-serif;
+      font-size: 16px;
+      color: #555555;
+      margin-left: 8px;
+      line-height: 100%;
+    }
+  }
+
+  .card_body {
+    font-family: 'Segoe UI', SegoeUI, 'Helvetica Neue', Helvetica, Arial,
+      sans-serif;
+    font-size: 16px;
+    margin-top: 16px;
+  }
+}


### PR DESCRIPTION
# 実装した内容
- 要約カードの作成
- 全体要約部分の挿入
  - 要約内容は固定 ( API との接続含め別 PR でやります。 )
- 段落要約の挿入
  - 要約内容はほぼ固定 ( 段落毎に段落名は入れています。 )

# 全体要約部分
## 実装したもの
![image](https://github.com/advanced-microsoft-learn-innovators/mldi-extension/assets/49856559/5c6311b2-44ae-4f22-91b3-141452bc8aca)

要約内容は一旦固定で実装しています。

一応 `useEffect` を使用して表示時に文字列を入れる形で実装してはいます。

ローディング画面は別 PR で実装予定です。

# 段落要約機能
## 実装したもの
![image](https://github.com/advanced-microsoft-learn-innovators/mldi-extension/assets/49856559/3b7ea37f-6437-4856-9304-7169fcf11d07)

ほぼ全体要約と同じです。

段落毎の id と段落名を持ってきて要約内容にいれています。