### PR TITLE
タグへの対応

### DIFF
--- a/background/messages/api.ts
+++ b/background/messages/api.ts
@@ -32,11 +32,15 @@ const handleApi = (
         // );
         console.log(`fetchWordDescription: ${word}`);
         const response = {
-          data: `I cannot describe ${word}.`,
+          data: {
+            description: `I cannot describe ${word}.`,
+            tags: ['Teams', 'Microsoft365']
+          },
           status: 200
         };
         sendResponse({
-          description: response.data
+          description: response.data.description,
+          tags: response.data.tags
         });
       })();
       return;

--- a/contents/components/WordDescriptionCard.tsx
+++ b/contents/components/WordDescriptionCard.tsx
@@ -6,6 +6,7 @@ export const WordDescriptionCard = () => {
   const [isShowCard, setIsShowCard] = useState(false);
   const [word, setWord] = useState(null);
   const [description, setDescription] = useState(null);
+  const [tags, setTags] = useState([]);
   const [rect, setRect] = useState(null);
   const [timeoutId, setTimeoutId] = useState(null);
 
@@ -39,21 +40,21 @@ export const WordDescriptionCard = () => {
   }, []);
 
   const fetchDescription = async (word: string) => {
-    const wordDescription = (
-      await chrome.runtime.sendMessage({
-        type: 'api',
-        command: 'fetchWordDescription',
-        data: {
-          word: word
-        }
-      })
-    ).description;
-    setDescription(wordDescription);
+    const response = await chrome.runtime.sendMessage({
+      type: 'api',
+      command: 'fetchWordDescription',
+      data: {
+        word: word
+      }
+    });
+    setDescription(response.description);
+    setTags(response.tags);
   };
 
   const hideCard = () => {
     setWord('');
     setDescription('');
+    setTags([]);
     setRect(null);
     setIsShowCard(false);
     setTimeoutId(null);
@@ -165,7 +166,13 @@ export const WordDescriptionCard = () => {
     >
       <div className="word">{word}</div>
       <div className="description">{description}</div>
-      <div className="tags">#Microsoft365 #Skype</div>
+      <div className="tags">
+        {tags.map((tag, index) => (
+          <span key={index} className="tag">
+            #{tag}&nbsp;
+          </span>
+        ))}
+      </div>
       <div
         className="bubble_tip"
         style={{

--- a/contents/styles/WordDescriptionCard.scss
+++ b/contents/styles/WordDescriptionCard.scss
@@ -31,6 +31,10 @@
     font-family: $default-font-family;
     margin-top: 4px;
     width: 100%;
+
+    .tag {
+      font-family: $default-font-family;
+    }
   }
 
   .bubble_tip {


### PR DESCRIPTION
# 概要
- base #7 
- 単語の説明を取得する際に一緒にタグも取得する
![image](https://github.com/user-attachments/assets/6a242b49-aedd-4814-ae06-8bc16469df00)

# 詳細
- 同じ API 内で詳細とタグを取得しています。
- backend 側の API は現時点では一緒の想定です。
  - ですが、SW 内で帰るだけなのでサクッと直せる範囲(のはず)です。 