### PR TITLE
単語説明表示のための API との連携

### DIFF
--- a/background/messages/api.ts
+++ b/background/messages/api.ts
@@ -19,7 +19,7 @@ const handleApi = (
     case MessageApiCommand.FETCH_TERMS:
       // fetch terms
       (async () => {
-        await fetchTerms(message, sendResponse);
+        await fetchTerms(sendResponse);
       })();
       return;
     case MessageApiCommand.GET_IS_SHOW_DESCRIPTION:

--- a/background/messages/api.ts
+++ b/background/messages/api.ts
@@ -1,8 +1,8 @@
 import { storage } from 'background';
 import { MessageApiCommand, type Message } from '~types';
 import { Logger } from '~utils';
-import { fetchSummary } from './apis/fetchSummary';
-import { fetchTerms } from './apis/fetchTerms';
+import fetchSummary from './apis/fetchSummary';
+import fetchTerms from './apis/fetchTerms';
 
 const handleApi = (
   message: Message,
@@ -19,7 +19,7 @@ const handleApi = (
     case MessageApiCommand.FETCH_TERMS:
       // fetch terms
       (async () => {
-        await fetchTerms(sendResponse);
+        await fetchTerms(message, sendResponse);
       })();
       return;
     case MessageApiCommand.GET_IS_SHOW_DESCRIPTION:

--- a/background/messages/apis/fetchSummary.ts
+++ b/background/messages/apis/fetchSummary.ts
@@ -1,10 +1,10 @@
-import { Logger, sendMessage } from '~utils';
+import { Logger, sendMessage, sleep } from '~utils';
 import { storage } from 'background';
 import type { AxiosResponse } from 'axios';
 import axios from 'axios';
 import { MessageToBrowserCommand, MessageType, type Message } from '~types';
 
-export const fetchSummary = async (message: Message) => {
+const fetchSummary = async (message: Message) => {
   // get document_id and uuid
   const res = await sendMessage(true, {
     type: MessageType.TO_BROWSER,
@@ -14,7 +14,7 @@ export const fetchSummary = async (message: Message) => {
   const uuid = res.uuid;
 
   // get url
-  const url = message.data.url;
+  const url = message.data.url.split('#')[0];
 
   // get heading level setting
   const isSummaryHeadeingLevels = (await storage.get(
@@ -30,6 +30,7 @@ export const fetchSummary = async (message: Message) => {
   Logger.info(`isSummaryHeadeingLevels.h4: ${isSummaryHeadeingLevels['h4']}`);
   const restApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/summary-contents/${uuid}?url=${url}&summarySectionLevels=${isSummaryHeadeingLevels['h2']}&summarySectionLevels=${isSummaryHeadeingLevels['h3']}&summarySectionLevels=${isSummaryHeadeingLevels['h4']}`;
   Logger.info(`restApiUrl: ${restApiUrl}`);
+
   const sendResponse = async (
     status: number,
     mainSummary: string,
@@ -63,13 +64,73 @@ export const fetchSummary = async (message: Message) => {
       data.headingSection.forEach((section) => {
         headingSummaries[section.id] = section.sectionSummary;
       });
-
       await sendResponse(status, data.mainSummary, headingSummaries);
+      return;
     }
   } catch (error) {
+    if (error.response.status === 404) {
+      // if 404, try create summary
+      const restPostApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/summary-contents`;
+      Logger.info(`restPostApiUrl: ${restPostApiUrl}`);
+      Logger.info('There is no summary. Create summary.');
+      try {
+        const response: AxiosResponse = await axios.post(restPostApiUrl, {
+          url: url
+        });
+        const postStatus = response.status;
+        Logger.info(`Summary Creation request sent: ${postStatus}`);
+        if (postStatus === 201) {
+          // wait for summary to be created
+          while (true) {
+            try {
+              Logger.info('chech if summary is created.');
+              const response: AxiosResponse = await axios.get(restApiUrl);
+              if (response.status === 200) {
+                const { data, status } = response;
+                Logger.info(`status: ${status}`);
+                let headingSummaries = {};
+                if (data?.headingSection.length > 0) {
+                  // ensure data might be undefined
+                  data.headingSection.forEach((section) => {
+                    headingSummaries[section.id] = section.sectionSummary;
+                  });
+                  await sendResponse(
+                    status,
+                    data.mainSummary,
+                    headingSummaries
+                  );
+                }
+                break;
+              }
+            } catch (error) {
+              if (error.response.status === 404) {
+                Logger.info('Summary is not created yet. Wait for 5 seconds.');
+                await sleep(5000);
+                continue;
+              } else {
+                Logger.error(
+                  `get summary error after create request: ${error}`
+                );
+                await sendResponse(500, '', '');
+                return;
+              }
+            }
+          }
+        } else {
+          Logger.error(`create summary error: ${postStatus}`);
+          await sendResponse(500, '', '');
+          return;
+        }
+      } catch (error) {
+        Logger.error(`createSummary error: ${error}`);
+        await sendResponse(500, '', '');
+        return;
+      }
+    }
     Logger.error(`fetchSummary error: ${error}`);
     await sendResponse(500, '', '');
+    return;
   }
-
-  Logger.info('fetchSummary response');
 };
+
+export default fetchSummary;

--- a/background/messages/apis/fetchTerms.ts
+++ b/background/messages/apis/fetchTerms.ts
@@ -1,8 +1,61 @@
-import type { Message } from '~types';
+import { MessageToBrowserCommand, MessageType, type Message } from '~types';
+import { Logger, sendMessage, sleep } from '~utils';
+import axios from 'axios';
+import { type AxiosResponse } from 'axios';
 
-export const fetchTerms = async (
-  message: Message,
-  sendResponse: (response?: any) => void
-) => {
-  // write fetch terms logic.
+export const fetchTerms = async (sendResponse: (response?: any) => void) => {
+  // get document_id and uuid
+  const [tab] = await chrome.tabs.query({
+    active: true,
+    lastFocusedWindow: true
+  });
+  const res = await sendMessage(true, {
+    type: MessageType.TO_BROWSER,
+    command: MessageToBrowserCommand.GET_DOCUMENT_IDS
+  });
+  const documentId = res.documentId;
+  const uuid = res.uuid;
+  Logger.info(`documentId: ${documentId}`);
+  Logger.info(`uuid: ${uuid}`);
+
+  const restGetApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms/${uuid}`;
+  Logger.info(`restGetApiUrl: ${restGetApiUrl}`);
+
+  try {
+    // 1. try get terms
+    const response: AxiosResponse = await axios.get(restGetApiUrl);
+    const { data, status } = response;
+    Logger.info(`get status: ${status}`);
+    if (status === 404) {
+      // 2. if 404, try create terms
+      const restPostApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms`;
+      Logger.info(`restPostApiUrl: ${restPostApiUrl}`);
+      const response: AxiosResponse = await axios.post(restPostApiUrl, {
+        uuid: uuid
+      });
+      const postStatus = response.status;
+      if (postStatus === 201) {
+        // 3. wait for terms to be created
+        while (true) {
+          const response: AxiosResponse = await axios.get(restGetApiUrl);
+          const getStatus = response.status;
+          Logger.info(`get status: ${getStatus}`);
+          if (getStatus === 200) {
+            break;
+          }
+          await sleep(5000);
+        }
+      } else {
+        Logger.error(`create terms error: ${postStatus}`);
+        return;
+      }
+    }
+
+    // 4. send terms
+    sendResponse({
+      wordList: response
+    });
+  } catch (error) {
+    Logger.error(`fetchWordList error: ${error}`);
+  }
 };

--- a/background/messages/apis/fetchTerms.ts
+++ b/background/messages/apis/fetchTerms.ts
@@ -18,6 +18,7 @@ const fetchTerms = async (
   Logger.info(`uuid: ${uuid}`);
 
   const url = message.data.url.split('#')[0];
+  Logger.info(`url: ${url}`);
 
   const restGetApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms/${uuid}?url=${url}`;
   Logger.info(`restGetApiUrl: ${restGetApiUrl}`);

--- a/background/messages/apis/fetchTerms.ts
+++ b/background/messages/apis/fetchTerms.ts
@@ -3,7 +3,10 @@ import { Logger, sendMessage, sleep } from '~utils';
 import axios from 'axios';
 import { type AxiosResponse } from 'axios';
 
-export const fetchTerms = async (sendResponse: (response?: any) => void) => {
+const fetchTerms = async (
+  message: Message,
+  sendResponse: (response?: any) => void
+) => {
   // get document_id and uuid
   const res = await sendMessage(true, {
     type: MessageType.TO_BROWSER,
@@ -14,7 +17,9 @@ export const fetchTerms = async (sendResponse: (response?: any) => void) => {
   Logger.info(`documentId: ${documentId}`);
   Logger.info(`uuid: ${uuid}`);
 
-  const restGetApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms/${uuid}`;
+  const url = message.data.url.split('#')[0];
+
+  const restGetApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms/${uuid}?url=${url}`;
   Logger.info(`restGetApiUrl: ${restGetApiUrl}`);
 
   try {
@@ -22,36 +27,61 @@ export const fetchTerms = async (sendResponse: (response?: any) => void) => {
     const response: AxiosResponse = await axios.get(restGetApiUrl);
     const { data, status } = response;
     Logger.info(`get status: ${status}`);
-    if (status === 404) {
-      // 2. if 404, try create terms
-      const restPostApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms`;
-      Logger.info(`restPostApiUrl: ${restPostApiUrl}`);
-      const response: AxiosResponse = await axios.post(restPostApiUrl, {
-        uuid: uuid
-      });
-      const postStatus = response.status;
-      if (postStatus === 201) {
-        // 3. wait for terms to be created
-        while (true) {
-          const response: AxiosResponse = await axios.get(restGetApiUrl);
-          const getStatus = response.status;
-          Logger.info(`get status: ${getStatus}`);
-          if (getStatus === 200) {
-            break;
-          }
-          await sleep(5000);
-        }
-      } else {
-        Logger.error(`create terms error: ${postStatus}`);
-        return;
-      }
-    }
 
-    // 4. send terms
+    // 2. if there is no error, send response
     sendResponse({
       wordList: response
     });
   } catch (error) {
-    Logger.error(`fetchWordList error: ${error}`);
+    if (error.response.status === 404) {
+      // 2. if 404, try create terms
+      const restPostApiUrl = `${process.env.PLASMO_PUBLIC_BACKEND_DOMAIN}/documents/${documentId}/terms`;
+      Logger.info(`restPostApiUrl: ${restPostApiUrl}`);
+      try {
+        const response: AxiosResponse = await axios.post(restPostApiUrl, {
+          url: url
+        });
+        Logger.info(
+          `Terms creation request sent successfully.: ${response.status}`
+        );
+      } catch (error) {
+        if (error.response.status === 409) {
+          Logger.info(`Terms are already created.`);
+        } else {
+          Logger.error(`post terms creation request: ${error}`);
+          sendResponse({
+            wordList: []
+          });
+          return;
+        }
+      }
+
+      // 3. wait for terms to be created
+      while (true) {
+        try {
+          const response: AxiosResponse = await axios.get(restGetApiUrl);
+          if (response.status === 200) {
+            sendResponse({
+              wordList: response
+            });
+            break;
+          }
+        } catch (error) {
+          if (error.response.status === 404) {
+            Logger.info(`Terms are not created yet. Wait for 5 seconds.`);
+            await sleep(5000);
+            continue;
+          } else {
+            Logger.error(`fetch Terms error: ${error}`);
+            return;
+          }
+        }
+      }
+    } else {
+      Logger.error(`fetch Terms error: ${error}`);
+      return;
+    }
   }
 };
+
+export default fetchTerms;

--- a/background/messages/apis/fetchTerms.ts
+++ b/background/messages/apis/fetchTerms.ts
@@ -5,10 +5,6 @@ import { type AxiosResponse } from 'axios';
 
 export const fetchTerms = async (sendResponse: (response?: any) => void) => {
   // get document_id and uuid
-  const [tab] = await chrome.tabs.query({
-    active: true,
-    lastFocusedWindow: true
-  });
   const res = await sendMessage(true, {
     type: MessageType.TO_BROWSER,
     command: MessageToBrowserCommand.GET_DOCUMENT_IDS

--- a/utils.ts
+++ b/utils.ts
@@ -25,7 +25,7 @@ export class Logger {
   }
 
   public static error(message: string) {
-    console.log(`[ERR] ${message}`);
+    console.error(`[ERR] ${message}`);
   }
 }
 


### PR DESCRIPTION
前提 PR #19 

- 基本的には実装済みです。
- しかし、 `POST /api/v1/documents/{document_id}/summary-contents` が 500 エラーで帰ってきている状況です。
  - Swagger で試しても同様のためバックエンド側の事象...?
- `POST  /api/v1/documents/{document_id}/terms` も 409 エラーが返ってきている状況です。
  - GET しても 404 が返ってきているため、term 自体は作成されていないはず。。。？
  - 上記同様 Swagger で試した際にも発生しているため、バックエンド側の事象と判断。

バックエンド側の事象は単純に localhost だと動かないって話ですかね。。。？